### PR TITLE
Enable lexical binding

### DIFF
--- a/json-mode.el
+++ b/json-mode.el
@@ -1,4 +1,4 @@
-;;; json-mode.el --- Major mode for editing JSON files
+;;; json-mode.el --- Major mode for editing JSON files -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011-2023 Josh Johnston, taku0
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.
